### PR TITLE
Require space after '*****' in section start

### DIFF
--- a/osg-system-profiler-viewer
+++ b/osg-system-profiler-viewer
@@ -33,7 +33,7 @@ def load_pdata_from_handle(fh):
     in_files_section = False
     in_file = False
     for line in fh:
-        section_match = re.match(r'[*]{5}\s*(.+?)\s*$', line)
+        section_match = re.match(r'[*]{5}\s+(.+?)\s*$', line)
         file_match = re.match(r'File:\s*(.+?)\s*$', line)
 
         end_of_section = section_match or (in_files_section and file_match)


### PR DESCRIPTION
This is necessary to avoid sealert output (which separates sections with
'******') from creating additional sections in the viewer.
