### PR TITLE
Include dump of tomcat server.xml (SOFTWARE-1099)

### DIFF
--- a/osg-system-profiler
+++ b/osg-system-profiler
@@ -50,6 +50,16 @@ dump_file()
     echo ""
 }
 
+dump_files_that_exist()
+{
+    local FILENAME
+    for FILENAME in "$@"; do
+        if [[ -f $FILENAME ]]; then
+            dump_file "$FILENAME"
+        fi
+    done
+}
+
 dump_files_in_dir()
 {
     DIR=$1
@@ -271,6 +281,8 @@ if $rpm_install; then
     dump_files_in_dir "/etc/yum.repos.d/"
 
     dump_files_in_dir "/etc/globus/"
+
+    dump_files_that_exist /etc/tomcat{5,6,}/server.xml
 
     tail_log /var/log/globus-gatekeeper.log 200
     tail_log /var/log/edg-mkgridmap.log 50


### PR DESCRIPTION
We wanted to have a way to detect and warn if trustmanager-tomcat's
configure.sh was not run, but we'll settle for a dump of the tomcat
config, per Brian B's comment in SOFTWARE-727.

The tomcat{5,6,} business is just to handle the various tomcat versions,
including tomcat 7.
