### PR TITLE
Use larger fonts

### DIFF
--- a/osg-system-profiler-viewer
+++ b/osg-system-profiler-viewer
@@ -8,6 +8,7 @@ import re
 import subprocess
 import sys
 import urllib2
+import tkFont
 
 
 
@@ -114,26 +115,29 @@ class Application(Frame):
         Frame.__init__(self, master)
         self.pack(fill=BOTH, expand=True)
 
+        self.font = tkFont.Font(family='Sans', size=12)
+        self.textfont = tkFont.Font(family='Monospace', size=12)
+
         self.top = Frame(self)
         self.top.pack(side=TOP, fill=X)
 
-        self.quit_btn = Button(self.top, text="QUIT", fg="red", command=self.quit)
+        self.quit_btn = Button(self.top, text="QUIT", fg="red", command=self.quit, font=self.font)
         self.quit_btn.pack(side=LEFT)
 
-        self.copy_section_btn = Button(self.top, text="Copy Section to X Clipboard", command=self.copy_section)
+        self.copy_section_btn = Button(self.top, text="Copy Section to X Clipboard", command=self.copy_section, font=self.font)
         self.copy_section_btn.pack(side=LEFT)
 
         self.bot = Frame(self)
         self.bot.pack(side=BOTTOM, fill=BOTH, expand=True)
 
-        self.section_lbx = Listbox(self.bot, selectmode=BROWSE)
+        self.section_lbx = Listbox(self.bot, selectmode=BROWSE, font=self.font)
         self.section_lbx.pack(side=LEFT, fill=BOTH, expand=True)
         self.current = None
 
-        self.label = Label(self.top, text="")
+        self.label = Label(self.top, text="", font=self.font)
         self.label.pack(side=LEFT, fill=X)
 
-        self.text = ScrolledText.ScrolledText(self.bot)
+        self.text = ScrolledText.ScrolledText(self.bot, font=self.textfont)
         self.text.pack(side=RIGHT, fill=BOTH, expand=True)
 
         self.pdata = pdata


### PR DESCRIPTION
Also, use XFT-rendered fonts instead of bitmap fonts, so they're properly scaled on a HiDPI display.